### PR TITLE
Adding Gatsby Plugin keywords in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "type": "git",
     "url": "https://github.com/nopelluhh/gatsby-source-google-calendar"
   },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+  ],
   "scripts": {
     "build": "tsc"
   },


### PR DESCRIPTION
Hello 👋 

As part of https://github.com/gatsbyjs/gatsby/issues/14013, I would like to add `gatsby` and `gatsby-plugin` keywords to the `package.json` file of your source plugin.

It is documented in https://www.gatsbyjs.org/contributing/submit-to-plugin-library/ if you would like to know more about it.

If you accept to merge this PR, could you also publish a patch version of your source plugin on NPM? Let me know if I can assist in any way with this. 🙂  

Thank you very much!

NB. To give you an idea, this is what it would look like on NPM after you publish a patch version:
<img width="810" alt="Screenshot 2019-05-14 at 21 14 52" src="https://user-images.githubusercontent.com/22741774/57725457-7bbd9880-768d-11e9-885c-229e9682045e.png">
